### PR TITLE
Approach app structure via MsgFor* instead of translators

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -87,6 +87,8 @@ update msg model =
                 ( { model | silence = silence, silences = silences, route = SilencesRoute silencesRoute, filter = filter }
                 , Cmd.map silenceTranslator silencesCmd
                 )
+        NavigateToStatus ->
+            ({ model | route=StatusRoute }, Cmd.none)
 
         Silences silencesMsg ->
             let
@@ -132,6 +134,8 @@ urlUpdate location =
 
             AlertsRoute alertsRoute ->
                 NavigateToAlerts alertsRoute
+            StatusRoute ->
+                NavigateToStatus
 
             _ ->
                 -- TODO: 404 page

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -6,14 +6,14 @@ import Time
 import Parsing
 import Views
 import Alerts.Update
-import Alerts.Types exposing (Route(Receiver))
 import Types exposing (..)
 import Utils.Types exposing (..)
 import Utils.Date exposing (toISO8601, unixEpochStart)
-import Silences.Api
 import Silences.Types exposing (Silence, nullTime, nullSilence)
 import Silences.Update
 import Translators exposing (alertTranslator, silenceTranslator)
+import Status.Types exposing (StatusModel)
+import Status.Update exposing (update)
 
 
 main : Program Never Model Msg
@@ -44,7 +44,7 @@ init location =
                     { text = Nothing, receiver = Nothing, showSilenced = Nothing }
 
         ( model, msg ) =
-            update (urlUpdate location) (Model Loading Loading Loading route filter unixEpochStart)
+            update (urlUpdate location) (Model Loading Loading Loading route filter unixEpochStart (StatusModel Nothing))
     in
         model ! [ msg, Task.perform UpdateCurrentTime Time.now ]
 
@@ -87,8 +87,9 @@ update msg model =
                 ( { model | silence = silence, silences = silences, route = SilencesRoute silencesRoute, filter = filter }
                 , Cmd.map silenceTranslator silencesCmd
                 )
+
         NavigateToStatus ->
-            ({ model | route=StatusRoute }, Cmd.none)
+            ( { model | route = StatusRoute }, Cmd.none )
 
         Silences silencesMsg ->
             let
@@ -121,6 +122,13 @@ update msg model =
         UpdateCurrentTime time ->
             ( { model | currentTime = toISO8601 time }, Cmd.none )
 
+        MsgForStatus msg ->
+            let
+                ( status, cmd ) =
+                    Status.Update.update msg model.status
+            in
+                ( { model | status = status }, cmd )
+
 
 urlUpdate : Navigation.Location -> Msg
 urlUpdate location =
@@ -134,6 +142,7 @@ urlUpdate location =
 
             AlertsRoute alertsRoute ->
                 NavigateToAlerts alertsRoute
+
             StatusRoute ->
                 NavigateToStatus
 

--- a/src/Parsing.elm
+++ b/src/Parsing.elm
@@ -2,6 +2,7 @@ module Parsing exposing (..)
 
 import Alerts.Parsing exposing (alertsParser)
 import Silences.Parsing exposing (silencesParser)
+import Status.Parsing exposing (statusParser)
 import Navigation
 import Types exposing (Route(..))
 import UrlParser exposing ((</>), (<?>), Parser, int, map, oneOf, parseHash, s, string, stringParam)
@@ -53,6 +54,7 @@ routeParser : Parser (Route -> a) a
 routeParser =
     oneOf
         [ map SilencesRoute silencesParser
+        , map StatusRoute statusParser
         , map AlertsRoute alertsParser
         , map TopLevel topLevelParser
         ]

--- a/src/Status/Api.elm
+++ b/src/Status/Api.elm
@@ -1,0 +1,26 @@
+module Status.Api exposing (getStatus)
+
+import Utils.Api exposing (baseUrl)
+import Http
+import Status.Types exposing (StatusMsg(NewStatus), StatusResponse)
+import Json.Decode exposing (Decoder, map2, string, field, at)
+import Types exposing (Msg(MsgForStatus))
+
+
+getStatus : Cmd Msg
+getStatus =
+    let
+        url =
+            String.join "/" [ baseUrl, "status" ]
+
+        request =
+            Http.get url decodeStatusResponse
+    in
+        Http.send (NewStatus >> MsgForStatus) request
+
+
+decodeStatusResponse : Decoder StatusResponse
+decodeStatusResponse =
+    map2 StatusResponse
+        (field "status" string)
+        (at [ "data", "uptime" ] string)

--- a/src/Status/Parsing.elm
+++ b/src/Status/Parsing.elm
@@ -1,0 +1,7 @@
+module Status.Parsing exposing (statusParser)
+
+import UrlParser exposing (Parser, s, string, (</>))
+
+statusParser : Parser a a
+statusParser =
+    s "status"

--- a/src/Status/Parsing.elm
+++ b/src/Status/Parsing.elm
@@ -2,6 +2,7 @@ module Status.Parsing exposing (statusParser)
 
 import UrlParser exposing (Parser, s, string, (</>))
 
+
 statusParser : Parser a a
 statusParser =
     s "status"

--- a/src/Status/Types.elm
+++ b/src/Status/Types.elm
@@ -1,0 +1,29 @@
+module Status.Types exposing (StatusMsg(..), StatusModel, StatusResponse)
+
+import Http exposing (Error)
+
+
+type StatusMsg
+    = NewStatus (Result Http.Error StatusResponse)
+    | GetStatus
+
+
+type alias StatusModel =
+    { response : Maybe StatusResponse
+    }
+
+
+type alias VersionInfo =
+    { branch : String
+    , buildDate : String
+    , buildUser : String
+    , goVersion : String
+    , revision : String
+    , version : String
+    }
+
+
+type alias StatusResponse =
+    { status : String
+    , uptime : String
+    }

--- a/src/Status/Update.elm
+++ b/src/Status/Update.elm
@@ -1,0 +1,18 @@
+module Status.Update exposing (update)
+
+import Types exposing (Msg)
+import Status.Types exposing (StatusModel, StatusMsg(GetStatus, NewStatus), StatusResponse)
+import Status.Api exposing (getStatus)
+
+
+update : StatusMsg -> StatusModel -> ( StatusModel, Cmd Msg )
+update msg model =
+    case msg of
+        GetStatus ->
+            ( model, getStatus )
+
+        NewStatus (Ok response) ->
+            ( { model | response = Just response }, Cmd.none )
+
+        NewStatus (Err err) ->
+            ( model, Cmd.none )

--- a/src/Status/Views.elm
+++ b/src/Status/Views.elm
@@ -1,0 +1,8 @@
+module Status.Views exposing (view)
+
+import Html exposing (Html, h1, text)
+import Types exposing (Model, Msg)
+
+view :  model -> Html Msg
+view model =
+    h1 [] [ text "Status Page" ]

--- a/src/Status/Views.elm
+++ b/src/Status/Views.elm
@@ -1,8 +1,39 @@
 module Status.Views exposing (view)
 
-import Html exposing (Html, h1, text)
-import Types exposing (Model, Msg)
+import Html exposing (Html, text, button, div, li, ul, b)
+import Html.Events exposing (onClick)
+import Status.Types exposing (StatusMsg(GetStatus), StatusResponse)
+import Types exposing (Msg(MsgForStatus), Model)
 
-view :  model -> Html Msg
+
+view : Model -> Html Types.Msg
 view model =
-    h1 [] [ text "Status Page" ]
+    div []
+        [ button [ onClick (MsgForStatus <| GetStatus) ] [ text "Get Status" ]
+        , ul []
+            [ li []
+                [ b [] [ text "Status: " ], text (getStatus model.status.response) ]
+            , li []
+                [ b [] [ text "Uptime: " ], text (getUptime model.status.response) ]
+            ]
+        ]
+
+
+getStatus : Maybe StatusResponse -> String
+getStatus maybeResponse =
+    case maybeResponse of
+        Nothing ->
+            "No status information available"
+
+        Just response ->
+            response.status
+
+
+getUptime : Maybe StatusResponse -> String
+getUptime maybeResponse =
+    case maybeResponse of
+        Nothing ->
+            "No version information available"
+
+        Just response ->
+            response.uptime

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -29,6 +29,7 @@ type Msg
     | UpdateFilter Filter String
     | NavigateToAlerts Alerts.Types.Route
     | NavigateToSilences Silences.Types.Route
+    | NavigateToStatus
     | Alerts AlertsMsg
     | Silences SilencesMsg
     | RedirectAlerts
@@ -40,5 +41,6 @@ type Msg
 type Route
     = SilencesRoute Silences.Types.Route
     | AlertsRoute Alerts.Types.Route
+    | StatusRoute
     | TopLevel
     | NotFound

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -4,7 +4,7 @@ module Types exposing (..)
 
 import Alerts.Types exposing (AlertGroup, AlertsMsg, Alert)
 import Silences.Types exposing (SilencesMsg, Silence)
-import Http exposing (Error)
+import Status.Types exposing (StatusModel, StatusMsg)
 import ISO8601
 import Time
 import Utils.Types exposing (ApiData, Filter)
@@ -21,6 +21,7 @@ type alias Model =
     , route : Route
     , filter : Filter
     , currentTime : ISO8601.Time
+    , status : StatusModel
     }
 
 
@@ -36,6 +37,7 @@ type Msg
     | NewUrl String
     | Noop
     | UpdateCurrentTime Time.Time
+    | MsgForStatus StatusMsg
 
 
 type Route

--- a/src/Views.elm
+++ b/src/Views.elm
@@ -2,12 +2,13 @@ module Views exposing (..)
 
 import Html exposing (Html, text, div)
 import Html.Attributes exposing (class)
-import Types exposing (Msg, Model, Route(SilencesRoute, AlertsRoute))
+import Types exposing (Msg, Model, Route(SilencesRoute, AlertsRoute, StatusRoute))
 import Utils.Types exposing (ApiResponse(..))
 import Utils.Views exposing (error, loading, notFoundView)
 import Translators exposing (alertTranslator, silenceTranslator)
 import Silences.Views
 import Alerts.Views
+import Status.Views
 import NavBar.Views exposing (appHeader)
 
 
@@ -32,6 +33,9 @@ links =
 appBody : Model -> Html Msg
 appBody model =
     case model.route of
+        StatusRoute ->
+            Status.Views.view model
+
         AlertsRoute route ->
             case model.alertGroups of
                 Success alertGroups ->


### PR DESCRIPTION
Instead of using ForSelf and ForParent, messages are wrapped by a message
per view, like e.g. MsgForStatus. The global update function then hands
each message to its corresponding sub-update function. So the message
"MsgForStatus getStatus" is redirected to the Status.Update.update
function.